### PR TITLE
[issue #1218] Annotation Processors that have an (internal) dependenc…

### DIFF
--- a/buildScripts/ivy-repo/org.projectlombok-lombok.patcher-0.22.xml
+++ b/buildScripts/ivy-repo/org.projectlombok-lombok.patcher-0.22.xml
@@ -1,5 +1,5 @@
 <ivy-module version="2.0">
-	<info organisation="org.projectlombok" module="lombok.patcher" revision="0.20" publication="20150408000000">
+	<info organisation="org.projectlombok" module="lombok.patcher" revision="0.22" publication="20161107000000">
 		<license name="MIT License" url="http://www.opensource.org/licenses/mit-license.php" />
 		<ivyauthor name="rzwitserloot" url="http://zwitserloot.com/" />
 		<ivyauthor name="rspilker" url="http://github.com/rspilker" />
@@ -9,6 +9,6 @@
 		<conf name="default" />
 	</configurations>
 	<publications>
-		<artifact conf="default" url="https://projectlombok.org/downloads/lombok.patcher-0.20.jar" />
+		<artifact conf="default" url="https://projectlombok.org/downloads/lombok.patcher-0.22.jar" />
 	</publications>
 </ivy-module>

--- a/buildScripts/ivy.xml
+++ b/buildScripts/ivy.xml
@@ -15,7 +15,7 @@
 		<conf name="javac7" />
 	</configurations>
 	<dependencies>
-		<dependency org="org.projectlombok" name="lombok.patcher" rev="0.20" conf="buildBase->default; runtime->default" />
+		<dependency org="org.projectlombok" name="lombok.patcher" rev="0.22" conf="buildBase->default; runtime->default" />
 		<dependency org="zwitserloot.com" name="cmdreader" rev="1.2" conf="buildBase->runtime; runtime" />
 		
 		<dependency org="junit" name="junit" rev="4.8.2" conf="test->default; contrib->sources" />

--- a/doc/changelog.markdown
+++ b/doc/changelog.markdown
@@ -3,6 +3,7 @@ Lombok Changelog
 
 ### v1.16.11 "Edgy Guinea Pig"
 * v1.16.10 is the latest release
+* BUGFIX: Annotation Processors that use ecj internally (dagger) no longer give linkage errors [Issue #1218](https://github.com/rzwitserloot/lombok/issues/1218)
 * BUGFIX: `val` in lambda expressions now work as expected [Issue #911](https://github.com/rzwitserloot/lombok/issues/911)
 * PLATFORM: Red Hat JBoss Developer Studio is now correctly identified by the installer [Issue #1164](https://github.com/rzwitserloot/lombok/issues/1164)
 * BUGFIX: delombok: for-loops with initializers that are not local variables would be generated incorrectly [Issue #1076](https://github.com/rzwitserloot/lombok/issues/1076)


### PR DESCRIPTION
…y on ecj (google's dagger project has this, don't know of any others), when run inside eclipse, bombs with a LinkageError. Fixed.